### PR TITLE
Fixed exception on GameplaySetup Dispose

### DIFF
--- a/ScoreRequirement/UI/SRSettingsViewController.cs
+++ b/ScoreRequirement/UI/SRSettingsViewController.cs
@@ -56,7 +56,7 @@ namespace ScoreRequirement.UI
 
         public void Dispose()
         {
-            if (GameplaySetup.instance != null)
+            if (GameplaySetup.IsSingletonAvailable)
                 GameplaySetup.instance.RemoveTab("ScoreRequirement");
             _levelCollectionNavigationController.didChangeDifficultyBeatmapEvent -= LevelCollectionNavigationControllerOndidChangeDifficultyBeatmapEvent;
         }


### PR DESCRIPTION
Basically what the title says, it fixes a minor exception whenever SRSettingsViewController was getting disposed. This because the GameplaySetup persistent singleton might have already been destroyed and calling .instance on it will result in an exception in that case.